### PR TITLE
Allow to define an additional instance redis prefix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,26 @@ You can also configure the namespace used by each class you create:
   end
 ```
 
+You can also configure the namespace used by each instance you create in addition to class and global namespace:
+
+```ruby
+  class CourseRecommender
+    include Predictor::Base
+
+    def initialize(prefix)
+      @prefix = prefix
+    end
+
+    # Simply override this instance method with the prefix you want
+    def get_redis_prefix
+      @prefix
+    end
+  end
+
+  recommender = CourseRecommender.new("super")
+  recommender.redis_prefix # "predictor:CourseRecommender:super"
+```
+
 Processing Items
 ---------------------
 As of 2.3.0, there are now multiple techniques available for processing item similarities. You can choose between them by setting a global default like `Predictor.processing_technique(:lua)` or setting a technique for certain classes like `CourseRecommender.processing_technique(:union)`. There are three values.

--- a/lib/predictor/base.rb
+++ b/lib/predictor/base.rb
@@ -63,8 +63,12 @@ module Predictor::Base
     }]
   end
 
+  def get_redis_prefix
+    nil # Override in subclass.
+  end
+
   def redis_prefix
-    [Predictor.get_redis_prefix, self.class.get_redis_prefix]
+    [Predictor.get_redis_prefix, self.class.get_redis_prefix, self.get_redis_prefix].compact
   end
 
   def similarity_limit

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -142,6 +142,21 @@ describe Predictor::Base do
       expect(br.redis_key(:another, :key)).to eq("predictor-test:BaseRecommender:another:key")
       expect(br.redis_key(:another, [:set, :of, :keys])).to eq("predictor-test:BaseRecommender:another:set:of:keys")
     end
+
+    it "should respect the instance prefix configuration setting" do
+      br = PrefixRecommender.new("foo")
+
+      expect(br.redis_key).to eq("predictor-test:PrefixRecommender:foo")
+      expect(br.redis_key(:another)).to eq("predictor-test:PrefixRecommender:foo:another")
+      expect(br.redis_key(:another, :key)).to eq("predictor-test:PrefixRecommender:foo:another:key")
+      expect(br.redis_key(:another, [:set, :of, :keys])).to eq("predictor-test:PrefixRecommender:foo:another:set:of:keys")
+
+
+      br.prefix = nil
+      expect(br.redis_key).to eq("predictor-test:PrefixRecommender")
+      expect(br.redis_key(:another)).to eq("predictor-test:PrefixRecommender:another")
+
+    end
   end
 
   describe "all_items" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,22 @@ class TestRecommender
   input_matrix :jaccard_one
 end
 
+class PrefixRecommender
+  include Predictor::Base
+
+  def initialize(prefix)
+    @prefix = prefix
+  end
+
+  def prefix=(new_prefix)
+    @prefix = new_prefix
+  end
+
+  def get_redis_prefix
+    @prefix
+  end
+end
+
 class Predictor::TestInputMatrix
   def initialize(opts)
     @opts = opts


### PR DESCRIPTION
This additional namespace gives more flexibility when it comes to handlind hundreds or thousands of matrices.